### PR TITLE
[podspec] Use vendored frameworks

### DIFF
--- a/Gigya-iOS-SDK.podspec
+++ b/Gigya-iOS-SDK.podspec
@@ -11,8 +11,7 @@ Pod::Spec.new do |s|
   s.source       = { :http => "https://raw.githubusercontent.com/jshier/GigyaSDK/master/#{s.version}/GigyaSDK.zip" }
   s.platform     = :ios, '7.0'
   s.source_files = 'GigyaSDK.framework/Versions/A/Headers/*.h'
-  s.preserve_paths = 'GigyaSDK.framework/*'
-  s.frameworks   = 'GigyaSDK', 'Foundation', 'Security'
-  s.xcconfig     = { 'FRAMEWORK_SEARCH_PATHS' => '"$(PODS_ROOT)/Gigya-iOS-SDK"' }
+  s.vendored_frameworks = 'GigyaSDK.framework'
+  s.frameworks   = 'Foundation', 'Security'
   s.requires_arc = false
 end


### PR DESCRIPTION
The use of the `$PODS_ROOT` environment variable has been deprecated and should not be used. It will be removed in future versions of CocoaPods. See https://github.com/CocoaPods/CocoaPods/issues/2449.

This switches to use the preferred `vendored_frameworks`. Please verify that the pod still works correctly, it passes lint but I don't actually depend on it.
